### PR TITLE
Fix compilation

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -17,7 +17,7 @@ lib_deps_external =
    joaolopesf/RemoteDebug
 
 [env:esp07]
-platform = espressif8266
+platform = espressif8266@2.6.3
 board = esp07
 framework = arduino
 build_flags =  -Wl,-Teagle.flash.512k64.ld -DIOTWEBCONF_DEBUG_DISABLED -DHARDWARE_SERIAL
@@ -27,7 +27,7 @@ lib_deps =
    ${common_env_data.lib_deps_external}
 
 [env:wemos_d1_mini]
-platform = espressif8266
+platform = espressif8266@2.6.3
 board = d1_mini
 framework = arduino
 build_flags =  


### PR DESCRIPTION
With the new 3.x platforms which use the newer ESP8266 3.x cores, one gets a ton of compile errors.

```
In file included from C:\Users\Max\.platformio\packages\framework-arduinoespressif8266\libraries\ESP8266WiFi\src/WiFiClient.h:27,
                 from C:\Users\Max\.platformio\packages\framework-arduinoespressif8266\libraries\ESP8266WiFi\src/ESP8266WiFi.h:39,
                 from .pio\libdeps\esp07\RemoteDebug\src/RemoteDebug.h:102,
                 from src/debug.h:5,
                 from C:\Users\Max\.platformio\packages\framework-arduinoespressif8266\cores\esp8266/Stream.h:25,
                 from C:\Users\Max\.platformio\packages\framework-arduinoespressif8266\cores\esp8266/HardwareSerial.h:32,
                 from C:\Users\Max\.platformio\packages\framework-arduinoespressif8266\cores\esp8266/Arduino.h:288,
                 from src\InverterValue.h:4,
                 from src\InverterValue.cpp:1:
C:\Users\Max\.platformio\packages\framework-arduinoespressif8266\cores\esp8266/Client.h:26:29: error: expected class-name before '{' token
   26 | class Client: public Stream {
      |                             ^
...
C:\Users\Max\.platformio\packages\framework-arduinoespressif8266\libraries\ESP8266WiFi\src/WiFiClientSecureBearSSL.h:223:32: error: expected ')' before '&' token
  223 |     uint8_t *_streamLoad(Stream& stream, size_t size);
      |                         ~      ^
      |                                )
C:\Users\Max\.platformio\packages\framework-arduinoespressif8266\libraries\ESP8266WiFi\src/WiFiClientSecureBearSSL.h:61:9: error: 'int BearSSL::WiFiClientSecureCtx::availableForWrite()' marked 'override', but does not override
   61 |     int availableForWrite() override;
      |         ^~~~~~~~~~~~~~~~~
C:\Users\Max\.platformio\packages\framework-arduinoespressif8266\libraries\ESP8266WiFi\src/WiFiClientSecureBearSSL.h:251:18: error: 'Stream' has not been declared
  251 |     size_t write(Stream& stream) /* Note this is not virtual */ { return _ctx->write(stream); }
      |                  ^~~~~~
C:\Users\Max\.platformio\packages\framework-arduinoespressif8266\libraries\ESP8266WiFi\src/WiFiClientSecureBearSSL.h:254:9: error: 'int BearSSL::WiFiClientSecure::availableForWrite()' marked 'override', but does not override
...
*** [.pio\build\wemos_d1_mini\src\main.cpp.o] Error 1
============================================== [FAILED] Took 8.68 seconds ==============================================

Environment    Status    Duration
-------------  --------  ------------
esp07          FAILED    00:00:12.379
wemos_d1_mini  FAILED    00:00:08.682
======================================== 2 failed, 0 succeeded in 00:00:21.061 ========================================
```

I haven't look in *detail* on what changed that makes this incompatible, maybe an update of the libraries suffices to to get them 3.x compatible, or a slight change in code inthis repo. Specifically the `RemoteDebug` lib seems to make problems, but no update at https://github.com/JoaoLopesF/RemoteDebug is available. So the fix I did here is just to revert back to an earlier platform version where compilation actually works.

```
Creating BIN file ".pio\build\wemos_d1_mini\firmware.bin" using "C:\Users\Max\.platformio\packages\framework-arduinoespressif8266@3.20704.0\bootloaders\eboot\eboot.elf" and ".pio\build\wemos_d1_mini\firmware.elf"
============================================= [SUCCESS] Took 11.71 seconds =============================================

Environment    Status    Duration
-------------  --------  ------------
esp07          SUCCESS   00:00:14.036
wemos_d1_mini  SUCCESS   00:00:11.713
============================================= 2 succeeded in 00:00:25.749 =============================================
```
